### PR TITLE
[ Update ] DB Config To Maintain Prod-Dev Parity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'redis', '~> 3.0'
 gem 'devise'
 gem 'dotenv-rails'
+gem 'mysql2', '< 0.5'
 
 group :development, :test do
   gem 'rspec-rails'
@@ -22,7 +23,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'sqlite3'
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
@@ -32,7 +32,6 @@ group :development do
 end
 
 group :production do
-  gem 'mysql2', '< 0.5'
 end
 
 source 'https://rails-assets.org' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -214,7 +213,6 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,31 +1,19 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
-default: &default
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
-
 development:
-  <<: *default
-  adapter: sqlite3
-  database: db/development.sqlite3
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-test:
-  <<: *default
-  adapter: sqlite3
-  database: db/test.sqlite3
-
-production:
-  adapter: 'mysql2'
-  host: localhost
+  adapter: <%= ENV.fetch("SNOTE_DB_ADAPTER") %>
+  host: <%= ENV.fetch("SNOTE_DB_HOST") %>
   database: <%= ENV.fetch("SNOTE_DB_DATABASE") %>
   username: <%= ENV.fetch("SNOTE_DB_USER") %>
   password: <%= ENV.fetch("SNOTE_DB_PASSWORD") %>
-  encoding: utf8
+  encoding: <%= ENV.fetch("SNOTE_DB_ENCODING") %>
   pool: 5
+  timeout: 5000
+
+production:
+  adapter: <%= ENV.fetch("SNOTE_DB_ADAPTER") %>
+  host: <%= ENV.fetch("SNOTE_DB_HOST") %>
+  database: <%= ENV.fetch("SNOTE_DB_DATABASE") %>
+  username: <%= ENV.fetch("SNOTE_DB_USER") %>
+  password: <%= ENV.fetch("SNOTE_DB_PASSWORD") %>
+  encoding: <%= ENV.fetch("SNOTE_DB_ENCODING") %>
+  pool: 5
+  timeout: 5000

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20180122134052) do
 
-  create_table "notes", force: :cascade do |t|
+  create_table "notes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
     t.string "title"
     t.text "body"
     t.integer "user_id"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20180122134052) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"


### PR DESCRIPTION
Update the database config to maintain production to development parity.
Changed the development database settings to use environment variables,
which includes DB Adapter, User, Password, Database and Host