### PR TITLE
[ Add ] Dockerize The Snote App

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+SNOTE_DB_ADAPTER=mysql2
+SNOTE_DB_HOST=db
+SNOTE_DB_DATABASE=snote_app_database
+SNOTE_DB_USER=example_user
+SNOTE_DB_PASSWORD=some_password
+SNOTE_DB_ENCODING=utf8
+MYSQL_DATABASE=snote_app_database
+MYSQL_ROOT_PASSWORD=root_password

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@
 /yarn-error.log
 
 .byebug_history
-.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:2.6.0
+
+RUN apt-get update -yqq \
+  && apt-get install -y nodejs \
+    mysql-client \
+    build-essential \
+    libpq-dev
+
+
+RUN gem install nokogiri
+
+WORKDIR /app
+COPY Gemfile* ./
+RUN bundle install
+COPY . .
+EXPOSE 3000
+CMD ["rails", "server", "-b", "0.0.0.0"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3"
+
+volumes:
+  db-data:
+    external: false
+
+services:
+  db:
+    image: mysql/mysql-server:latest
+    env_file: .env
+    volumes:
+      - ./files/mysql/:/docker-entrypoint-initdb.d/
+
+  app:
+    build: .
+    environment:
+      RAILS_ENV: development
+    volumes:
+      - .:/app
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+

--- a/files/mysql/init.sql
+++ b/files/mysql/init.sql
@@ -1,0 +1,4 @@
+CREATE USER 'example_user'@'%' IDENTIFIED BY 'some_password';
+GRANT ALL PRIVILEGES ON * . * TO 'example_user'@'%';
+FLUSH PRIVILEGES;
+ALTER USER 'example_user'@'%' IDENTIFIED WITH mysql_native_password BY 'some_password';


### PR DESCRIPTION
Dockerize the Snote app. This commit will create two container with name
snote_app_1 and snote_db_1, the snote_db_1 will be initialized with the
app user and database with required privileges. The details are fetched
from init.sql file located in ./files/mysql folder.