### PR TITLE
Add Rollbar Integration & Update Dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ SNOTE_DB_PASSWORD=some_password
 SNOTE_DB_ENCODING=utf8
 MYSQL_DATABASE=snote_app_database
 MYSQL_ROOT_PASSWORD=root_password
+ROLLBAR_ACCESS_TOKEN=your-rollbar-access-token

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 /yarn-error.log
 
 .byebug_history
+.env.development.local

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'devise'
 gem 'dotenv-rails'
 gem 'mysql2', '< 0.5'
+gem 'rollbar'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,8 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rollbar (2.18.2)
+      multi_json
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -208,6 +210,7 @@ DEPENDENCIES
   rails-assets-bootstrap!
   rails-assets-jquery!
   rails-assets-tether!
+  rollbar
   rspec-rails
   sass-rails (~> 5.0)
   shoulda-matchers

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,0 +1,71 @@
+Rollbar.configure do |config|
+  # Without configuration, Rollbar is enabled in all environments.
+  # To disable in specific environments, set config.enabled=false.
+
+  config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
+
+  # Here we'll disable in 'test':
+  if Rails.env.test?
+    config.enabled = false
+  end
+
+  # By default, Rollbar will try to call the `current_user` controller method
+  # to fetch the logged-in user object, and then call that object's `id`
+  # method to fetch this property. To customize:
+  # config.person_method = "my_current_user"
+  # config.person_id_method = "my_id"
+
+  # Additionally, you may specify the following:
+  # config.person_username_method = "username"
+  # config.person_email_method = "email"
+
+  # If you want to attach custom data to all exception and message reports,
+  # provide a lambda like the following. It should return a hash.
+  # config.custom_data_method = lambda { {:some_key => "some_value" } }
+
+  # Add exception class names to the exception_level_filters hash to
+  # change the level that exception is reported at. Note that if an exception
+  # has already been reported and logged the level will need to be changed
+  # via the rollbar interface.
+  # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
+  # 'ignore' will cause the exception to not be reported at all.
+  # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
+  #
+  # You can also specify a callable, which will be called with the exception instance.
+  # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
+
+  # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
+  # is not installed)
+  # config.use_async = true
+  # Supply your own async handler:
+  # config.async_handler = Proc.new { |payload|
+  #  Thread.new { Rollbar.process_from_async_handler(payload) }
+  # }
+
+  # Enable asynchronous reporting (using sucker_punch)
+  # config.use_sucker_punch
+
+  # Enable delayed reporting (using Sidekiq)
+  # config.use_sidekiq
+  # You can supply custom Sidekiq options:
+  # config.use_sidekiq 'queue' => 'default'
+
+  # If your application runs behind a proxy server, you can set proxy parameters here.
+  # If https_proxy is set in your environment, that will be used. Settings here have precedence.
+  # The :host key is mandatory and must include the URL scheme (e.g. 'http://'), all other fields
+  # are optional.
+  #
+  # config.proxy = {
+  #   host: 'http://some.proxy.server',
+  #   port: 80,
+  #   user: 'username_if_auth_required',
+  #   password: 'password_if_auth_required'
+  # }
+
+  # If you run your staging application instance in production environment then
+  # you'll want to override the environment reported by `Rails.env` with an
+  # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
+  # setup for Heroku. See:
+  # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
+  config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
+end


### PR DESCRIPTION
Added Rollbar integration to Snote app. Renamed the .env file to
.env.example and add variable for Rollbar Access Token. This
.env.example can be renamed to .env.development for development
environment or other accordingly and must always be add to .gitignore as
the .env file generally contain application secrets.